### PR TITLE
Fix start script in package.json to use node instead of nodemon

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon server.js",
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
This pull request makes a small change to the `backend/package.json` file. The `start` script has been updated to use `node` instead of `nodemon` for running `server.js`.