### PR TITLE
Add Vercel configuration for URL rewrites

### DIFF
--- a/frontend/battle-type/vercel.json
+++ b/frontend/battle-type/vercel.json
@@ -1,0 +1,1 @@
+{ "rewrites": [{ "source": "/(.*)", "destination": "/" }] }


### PR DESCRIPTION
This pull request includes a small configuration change to the `frontend/battle-type/vercel.json` file. The change adds a rewrite rule to redirect all requests to the root path.

* [`frontend/battle-type/vercel.json`](diffhunk://#diff-0e06f9975432f35b9ae52e85bb7dc7bf44f7a03652e18bb2cce7a8351d673a5bR1): Added a rewrite rule to redirect all requests (`/(.*)`) to the root path (`/`).