### PR TITLE
Fix getProfile endpoint to include 'api/user' prefix in userService.js

### DIFF
--- a/frontend/battle-type/src/services/userService.js
+++ b/frontend/battle-type/src/services/userService.js
@@ -38,7 +38,7 @@ export const userService = {
     getProfile: async () => {
         try {
             const token = localStorage.getItem('token');
-            const response = await fetch(`${BASE_URL}/profile`, {
+            const response = await fetch(`${BASE_URL}/api/user/profile`, {
                 headers: {
                     'Authorization': `Bearer ${token}`,
                 }


### PR DESCRIPTION
This pull request includes a small change to the `userService.js` file. The change updates the API endpoint for fetching user profile data to use a more specific path.